### PR TITLE
fix rendering error if list inside tt_container

### DIFF
--- a/js/turbotabs.js
+++ b/js/turbotabs.js
@@ -373,7 +373,7 @@
             var index = -1;
             var zbir = tab.length;
             for( var i = 0; i < zbir; i++ ){
-                (tab.eq(i)).appendTo(tabs.find('li').eq(i));
+                (tab.eq(i)).appendTo(tabs.find('> li').eq(i));
             }
             if( resized === 0 ){
                 sel.closest('html').find('head style[data-style="turbotab"]').append(' .'+random+' .tt_tabs h3{background: ' + settings.navBackground + ';} .'+ random +'.responsive .tt_tabs li, .'+ random +'.responsive .tt_tabs li.active, .'+ random +'.responsive .tt_tabs li:hover{background: '+ settings.backgroundColor +';}');


### PR DESCRIPTION
There is a bug if mode == 'vertical' and tt_tab includes list (ul + li).
The content lis and the tab lis are mixed. Some content will duplicate and some navigation lis are unusable.
This is fixed if you use selector ">li" instead of "li".
